### PR TITLE
fix: fix critical security vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:293.0.0-alpine
+FROM google/cloud-sdk:403.0.0-alpine
 
 COPY LICENSE README.md /
 


### PR DESCRIPTION
Synk.io reported 53 security vulnerabilities in the currently used base Docker
image (google/cloud-sdk:293.0.0-alpine). Seven of those vulnerabilities are
considered critical.
https://snyk.io/test/docker/google%2Fcloud-sdk%3A293.0.0-alpine

According to Snyk the Docker image google/cloud-sdk:403.0.0-alpine has zero
security vulnerabilities.
https://snyk.io/test/docker/google%2Fcloud-sdk%3A403.0.0-alpine

Therefore, this commit upgrades the base Docker image to fix the security
issues.